### PR TITLE
Task/1  generic category command handling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+### Overview:
+
+### Github Issue Links:
+[Task <task#>](https://github.com/nathandf/tapis-cli/issues/<task#>)
+
+### Summary of changes:
+-
+
+### Steps-to-test:
+-
+
+### Notes:

--- a/configs/settings.py
+++ b/configs/settings.py
@@ -31,7 +31,7 @@ DEFAULT_AUTH_METHOD = PASSWORD
 # See docstring for info on the below.
 ENVS = [ "develop", "staging", "prod" ]
 
-ENV = "develop"
+ENV = "prod"
 TENANT = "tacc"
 
 ENV = ENV + "." if (ENV != "prod") else ""

--- a/core/Category.py
+++ b/core/Category.py
@@ -8,6 +8,7 @@ import re
 import sys
 import types
 
+from typing import Dict
 from utils.Logger import Logger
 
 
@@ -18,6 +19,7 @@ class Category:
     should inherit from this category. See 'TapipyCategory.py' for an example.
     """
     options = []
+    keyword_args: Dict[str, str] = {}
     command = "help"
     logger = None
     exit = sys.exit
@@ -58,6 +60,10 @@ class Category:
         """ Any options for the command are logged to the class. """
         self.options = options
 
+        return
+
+    def set_keyword_args(self, keyword_args: Dict[str, str]) -> None:
+        self.keyword_args = keyword_args
         return
 
     def execute(self, args) -> None:

--- a/core/Category.py
+++ b/core/Category.py
@@ -30,9 +30,11 @@ class Category:
     def help(self, **args):
         """
         \nGeneral usage:
-        $tapis [category] [command] [args]
+        '*' indicates optional
+        $tapis [category] [options] [command] [args/keyword args]
         \nExamples:
         - tapis systems get [systemId]
+        - tapis systems getSystem --systemId [systemId]
         - tapis files upload [systems] [path/to/local/file] [destination/folder]
         - tapis systems update [path/to/definition/file]
         - tapis apps create [path/to/definition/file]

--- a/core/OpenApiCategory.py
+++ b/core/OpenApiCategory.py
@@ -13,13 +13,17 @@ class OpenApiCategory(TapipyCategory):
         TapipyCategory.__init__(self)
 
     def execute(self, args) -> None:
-        if len(args) > 0:
-            result = self.operation(*args)
-        else:
+        if len(args) == 0 and len(self.keyword_args) == 0:
             result = self.operation()
+        elif len(args) > 0 and len(self.keyword_args) == 0:
+            result = self.operation(*args)
+        elif len(args) == 0 and len(self.keyword_args) > 0:
+            result = self.operation(**self.keyword_args)
+        else:
+            result = self.operation(*args, **self.keyword_args)
 
-        print(result)
 
+        self.logger.log(result)
         return
 
     def set_operation(self, operation_name: str) -> None:

--- a/core/OpenApiCategory.py
+++ b/core/OpenApiCategory.py
@@ -13,18 +13,25 @@ class OpenApiCategory(TapipyCategory):
         TapipyCategory.__init__(self)
 
     def execute(self, args) -> None:
-        if len(args) == 0 and len(self.keyword_args) == 0:
-            result = self.operation()
-        elif len(args) > 0 and len(self.keyword_args) == 0:
-            result = self.operation(*args)
-        elif len(args) == 0 and len(self.keyword_args) > 0:
-            result = self.operation(**self.keyword_args)
-        else:
-            result = self.operation(*args, **self.keyword_args)
+        try:
+            if len(args) == 0 and len(self.keyword_args) == 0:
+                result = self.operation()
+            elif len(args) > 0 and len(self.keyword_args) == 0:
+                result = self.operation(*args)
+            elif len(args) == 0 and len(self.keyword_args) > 0:
+                result = self.operation(**self.keyword_args)
+            else:
+                result = self.operation(*args, **self.keyword_args)
 
+            if type(result) == enumerate:
+                for item in result:
+                    self.logger.log(item)
+                return
 
-        self.logger.log(result)
-        return
+            self.logger.log(result)
+            return
+        except Exception as e:
+            self.logger.error(e)
 
     def set_operation(self, operation_name: str) -> None:
         try:

--- a/core/OpenApiCategory.py
+++ b/core/OpenApiCategory.py
@@ -1,0 +1,39 @@
+from core.TapipyCategory import TapipyCategory
+
+# TODO Use client initialization logic from Tapipy in OpenApiCategory
+class OpenApiCategory(TapipyCategory):
+    """
+    Overwrites the execute method to access the
+    Tapipy client directly
+    """
+    operation = None
+    resource = None
+
+    def __init__(self):
+        TapipyCategory.__init__(self)
+
+    def execute(self, args) -> None:
+        if len(args) > 0:
+            result = self.operation(*args)
+        else:
+            result = self.operation()
+
+        print(result)
+
+        return
+
+    def set_operation(self, operation_name: str) -> None:
+        try:
+            self.operation = getattr(self.resource, operation_name)
+            return
+        except:
+            self.logger.error(f"{type(self.resource).__name__} has no operation '{operation_name}'\n")
+            self.exit(1)
+
+    def set_resource(self, resource_name: str) -> None:
+        try:
+            self.resource = getattr(self.client, resource_name)
+            return
+        except:
+            self.logger.error(f"{type(self).__name__} has no resource '{resource_name}'\n")
+            self.exit(1)

--- a/core/Router.py
+++ b/core/Router.py
@@ -22,7 +22,7 @@ class Router:
 
     def resolve(self, args: list[str]) -> tuple[Category, list[str]]:
         """ The command is resolved here. """
-        # The first step of command resolution is to check if a
+        # The first step of command resolution is to check if a 
         # user-defined category exists by the name provided in args. If it does,
         # import it
         category_name = args[0]

--- a/core/Router.py
+++ b/core/Router.py
@@ -1,68 +1,75 @@
 """ Handles the resolving (parsing) of commands and their options. """
 
 import re
-import sys
 
 from core.Category import Category
 from importlib import import_module
 from importlib.util import find_spec
 from utils.Logger import Logger
-
+from typing import List, Tuple
+from core.OpenApiCategory import OpenApiCategory
 
 class Router:
     """
     Commands and their options are passed into the router/resolver.
     The options are parsed and then the command is resolved.
     """
-    command_index = 1
-    logger = None
+    command_index: int = 1
+    logger: Logger = None
 
     def __init__(self):
         self.logger = Logger()
 
-    def resolve(self, args: list[str]) -> tuple[Category, list[str]]:
+    def resolve(self, args: List[str]) -> Tuple[Category, List[str]]:
         """ The command is resolved here. """
+        # Category name
+        category_name: str = args[0]
+        # Parse the options from the args.
+        options = self.parse_options(args[1:])
+        # Set the command on the category.
+        command_name: str = args[self.command_index]
+        # Every element in the args list after the command index are arguments
+        # for the category.
+        command_arguments = args[self.command_index+1:]
+
         # The first step of command resolution is to check if a 
-        # user-defined category exists by the name provided in args. If it does,
-        # import it
-        category_name = args[0]
+        # user-defined category exists by the name provided in args.
         if find_spec(f"categories.{category_name.capitalize()}") is not None:
             # Import and instantiate the category
             module = import_module( f"categories.{category_name.capitalize()}", "./" )
-            category = getattr(module, f"{category_name.capitalize()}")()
+            category: type[Category] = getattr(module, f"{category_name.capitalize()}")()
 
-            # Set the options on the category.
-            options = self.parse_options(args[1:])
+            if not hasattr(category, command_name):
+                # If the command being invoked doesn't exist on the category, 
+                # update the category to be an instance of core.OpenApiCategory
+                category = OpenApiCategory()
+                # Set the resource, operation, and options
+                category.set_resource(category_name)
+                category.set_operation(command_name)
+                category.set_options(options)
+
+                return (category, command_arguments)
+            
+            # Set the options and command
+            category.set_command(command_name)
             category.set_options(options)
 
-            # Set the command on the category.
-            command_name = args[self.command_index]
-            if not hasattr(category, args[self.command_index]):
-                # If the command being invoked doesn't exist on the category, 
-                # return a generic instance of TapipyCategory
-                # TODO implement tapipy category
-                pass
-                
-
-            category.set_command(command_name)
-
             # Return the category with command and options set.
-            # Every element in the args list after the command index are arguments
-            # for the category.
-            command_arguments = args[self.command_index+1:]
             return (category, command_arguments)
 
-        # If a user-defined category doesn't exist, return a generic instance 
-        # of TapipyCategory
-        # TODO implement tapipy category
-        
-        # No category was found by the provided name
-        # TODO Remove logging and exit line below once tapipy category is
-        # implemented
-        self.logger.error(f"Invalid category. '{category_name}' category not implemented")
-        sys.exit(1)
+        # If a user-defined category doesn't exist, return an instance
+        # of core.OpenApiCategory
+        category = OpenApiCategory()
 
-    def parse_options(self, args: list[str]):
+        # Set the resource, operation, and options
+        category.set_resource(category_name)
+        category.set_operation(command_name)
+        category.set_options(options)
+
+        return (category, command_arguments)
+        
+        
+    def parse_options(self, args: List[str]) -> List[str]:
         """ Checks to make sure the options are valid. """
         # Regex pattern for options.
         option_pattern = re.compile(r"^[-]{1,2}[a-z]+[a-z_]*$")

--- a/core/Router.py
+++ b/core/Router.py
@@ -6,12 +6,12 @@ from core.Category import Category
 from importlib import import_module
 from importlib.util import find_spec
 from utils.Logger import Logger
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 from core.OpenApiCategory import OpenApiCategory
 
 class Router:
     """
-    Commands and their options are passed into the router/resolver.
+    Commands and their options are passed into the router.
     The options are parsed and then the command is resolved.
     """
     command_index: int = 1
@@ -22,15 +22,20 @@ class Router:
 
     def resolve(self, args: List[str]) -> Tuple[Category, List[str]]:
         """ The command is resolved here. """
-        # Category name
-        category_name: str = args[0]
-        # Parse the options from the args.
-        options = self.parse_options(args[1:])
-        # Set the command on the category.
-        command_name: str = args[self.command_index]
-        # Every element in the args list after the command index are arguments
-        # for the category.
-        command_arguments = args[self.command_index+1:]
+
+        # Parse the arguments and extract the values
+        (
+            category_name,
+            command_name,
+            options,
+            keyword_args,
+            positional_args
+        ) = self.parse_args(args)
+
+        self.logger.debug(f"All args: {args}")
+        self.logger.debug(f"Options: {options}")
+        self.logger.debug(f"kwargs: {keyword_args}")
+        self.logger.debug(f"Positional args: {positional_args}")
 
         # The first step of command resolution is to check if a 
         # user-defined category exists by the name provided in args.
@@ -47,15 +52,17 @@ class Router:
                 category.set_resource(category_name)
                 category.set_operation(command_name)
                 category.set_options(options)
+                category.set_keyword_args(keyword_args)
 
-                return (category, command_arguments)
+                return (category, positional_args)
             
             # Set the options and command
             category.set_command(command_name)
             category.set_options(options)
+            category.set_keyword_args(keyword_args)
 
             # Return the category with command and options set.
-            return (category, command_arguments)
+            return (category, positional_args)
 
         # If a user-defined category doesn't exist, return an instance
         # of core.OpenApiCategory
@@ -65,24 +72,74 @@ class Router:
         category.set_resource(category_name)
         category.set_operation(command_name)
         category.set_options(options)
+        category.set_keyword_args(keyword_args)
 
-        return (category, command_arguments)
+        return (category, positional_args)
         
         
     def parse_options(self, args: List[str]) -> List[str]:
-        """ Checks to make sure the options are valid. """
+        """Extract options from the args"""
         # Regex pattern for options.
-        option_pattern = re.compile(r"^[-]{1,2}[a-z]+[a-z_]*$")
-
+        pattern = re.compile(r"^[-]{1}[a-z]+[a-z_]*$")
         # First arg in the args list is the category.
         # For every option found in the args list, increment the command_index
         # by 1. If none are found, then the command name is at index 1.
         options = []
         for option in args:
-            if re.match(option_pattern, option):
+            if pattern.match(option):
                 options.append(option)
                 self.command_index += 1
                 continue
             break
 
         return options
+
+    def parse_keyword_args(self, args: List[str]) -> Dict[str, str]:
+        # Regex pattern for keyword args and their values
+        # NOTE This is a weak pattern. Doesn't allow for "=" in 
+        # the value of the keword argument AND double quotes
+        # must be escaped on the command line.
+        # matches: --someKeywordArg="someVlaue"
+        # pattern = re.compile(r"[\s]{1}[-]{2}([\w]{1}[\w]*)[\s]*=[\s]*\"([\w\s\r\t\n!@#$%^&*()\-+\{\}\[\]|\\\/:;\"\'<>?\|,.`~]*)\"", re.MULTILINE | re.UNICODE)
+        
+        # This pattern is like the above but a little more flexible. Doesn't require
+        # equal sign or quotes surrounding the value
+        pattern = re.compile(r"(?<=[\s]){1}[-]{2}([\w]{1}[\w]*)[\s]+([\w\r\t\n!@#$%^&*()\-+\{\}\[\]|\\\/:;\"\'<>?\|,.`~=]*)(?=[\s])*", re.MULTILINE | re.UNICODE)
+        return (dict(pattern.findall(" " + " ".join(args))))
+
+    def parse_args(self, args: List[str]) -> Tuple[str, str, List, Dict, List]:
+        # Category name
+        category_name: str = args[0]
+        # Parse the options from the args. This also keeps determines the
+        # index of the command name via self.command_index
+        options = self.parse_options(args[1:])
+        # Set the command on the category.
+        command_name: str = args[self.command_index]
+        # Every element in the args list after the command index are arguments
+        # for the category.
+        command_args = args[self.command_index+1:]
+        keyword_args = self.parse_keyword_args(command_args)
+
+        # Remove all options and keyword args from the args list. Only
+        # positional arguments will remain
+        positional_args = []
+        keyword_indicies = []
+
+        for index, item in enumerate(command_args):
+            if re.match(r"[-]{2}([\w]{1}[\w]*)", item) is not None and index not in keyword_indicies:
+                # Append the index of key
+                keyword_indicies.append(index)
+                # Append the index of the value
+                keyword_indicies.append(index+1)
+        
+        for index, item in enumerate(command_args):
+            if index not in keyword_indicies:
+                positional_args.append(item)
+
+        return (
+            category_name,
+            command_name,
+            options,
+            keyword_args,
+            positional_args
+        )

--- a/core/TapipyCategory.py
+++ b/core/TapipyCategory.py
@@ -10,7 +10,7 @@ from tapipy.tapis import Tapis
 
 
 class TapipyCategory(Category):
-    """ A TAPIS-specific category parser. """
+    """ A TAPIS-specific category. """
     client: Union[Tapis, None] = None
 
     def __init__(self):

--- a/main.py
+++ b/main.py
@@ -1,9 +1,6 @@
-""" The main driver of the TAPIs command line tool. """
-
+""" The front-controller the TAPIs command line tool. """
 import sys
-
 from core.Router import Router
-
 
 def main():
     """ Resolve the category, command, options, and arguments, then execute them. """


### PR DESCRIPTION
### Overview:
Expose tapipy operations directly via OpenApiCategory if no user defined category exists, or the command on an existing user defined category doesn't exist 

### Github Issue Links:
[Task 1](https://github.com/nathandf/tapis-cli/issues/1)

### Summary of changes:
- Created OpenApiCategory that directly calls operations on Tapipy
- Handle for options, position arguments, and keyword arguments in the Router
- Added .github folder with PR template

### Steps-to-test:
- Demonstrate category override: Rename System category file to _Systems(so that the Router wont find it) and run the following `tapis systems getSystems --systemId <your_system_id_here>`
- Demonstrate command override: Rename System category file BACK to Systems and run the following `tapis systems getSystems --systemId <your_system_id_here>`. The user-defined systems category will now be found but the command will not. The result will be that Router will override the systems category and try to execute a Tapipy operation by the provided command name.
- Demonstrate user defined category: Run `tapis systems get <your_system_id_here>`. The Router will pick up the user-defined category and command and execute it

### Notes:
Made some changes to existing documentation. Didn't add much more in that regard. Will need to be done later.