### PR TITLE
Check provided keyword args against the operations required path_paramerters

### DIFF
--- a/core/OpenApiCategory.py
+++ b/core/OpenApiCategory.py
@@ -14,6 +14,8 @@ class OpenApiCategory(TapipyCategory):
 
     def execute(self, args) -> None:
         try:
+            self.validate_keyword_args()
+
             if len(args) == 0 and len(self.keyword_args) == 0:
                 result = self.operation()
             elif len(args) > 0 and len(self.keyword_args) == 0:
@@ -48,3 +50,14 @@ class OpenApiCategory(TapipyCategory):
         except:
             self.logger.error(f"{type(self).__name__} has no resource '{resource_name}'\n")
             self.exit(1)
+
+    def validate_keyword_args(self):
+        required_params = []
+        for param in self.operation.path_parameters:
+            if param.required:
+                required_params.append(param.name)
+
+        keyword_arg_keys = self.keyword_args.keys()
+        for param in required_params:
+            if param not in keyword_arg_keys:
+                raise Exception(f"'{param}' is a required keyword argument. Required keyword arguments: {required_params}")

--- a/core/Router.py
+++ b/core/Router.py
@@ -32,11 +32,6 @@ class Router:
             positional_args
         ) = self.parse_args(args)
 
-        self.logger.debug(f"All args: {args}")
-        self.logger.debug(f"Options: {options}")
-        self.logger.debug(f"kwargs: {keyword_args}")
-        self.logger.debug(f"Positional args: {positional_args}")
-
         # The first step of command resolution is to check if a 
         # user-defined category exists by the name provided in args.
         if find_spec(f"categories.{category_name.capitalize()}") is not None:


### PR DESCRIPTION
### Overview:
Keyword validator checks the keywords provided by the user against the operations path_parameters

### Github Issue Links:
[Task 8](https://github.com/nathandf/tapis-cli/issues/8)

### Summary of changes:
- Added keyword argument validator method
- Removed debugging code from Router

### Steps-to-test:
- Run `tapis files listFiles`. Will throw an error

### Notes:
