### PR TITLE
Update documentation to follow Python standards

### DIFF
--- a/categories/Apps.py
+++ b/categories/Apps.py
@@ -1,4 +1,4 @@
-""" Handles TAPIS functionality related to applications. """
+"""Handles TAPIS functionality related to applications."""
 
 import json
 import sys
@@ -8,7 +8,7 @@ from tapipy.errors import InvalidInputError, ServerDownError
 
 
 class Apps(TapipyCategory):
-    """ Contains all of the CRUD functions associated with applications. """
+    """Contains all of the CRUD functions associated with applications."""
     def __init__(self):
         TapipyCategory.__init__(self)
 
@@ -34,7 +34,7 @@ class Apps(TapipyCategory):
         return
 
     def create(self, app_definition_file) -> None:
-        """ Create a new application from an app definition JSON file. """
+        """Create a new application from an app definition JSON file."""
         try:
             definition = json.loads(open(app_definition_file, "r").read())
             self.client.apps.createAppVersion(**definition)
@@ -58,7 +58,7 @@ class Apps(TapipyCategory):
             return
 
     def disable(self, app_id) -> None:
-        """ Mark (all versions of) an application as unavailable for use. """
+        """Mark (all versions of) an application as unavailable for use."""
         try:
             self.client.apps.disableApp(appId=app_id)
             self.logger.success(f"The app '{app_id}' was disabled\n")
@@ -67,7 +67,7 @@ class Apps(TapipyCategory):
             self.logger.error(f"App not found with id '{app_id}'\n")          
 
     def enable(self, app_id) -> None:
-        """ Mark (all versions of) an application as available for use. """
+        """Mark (all versions of) an application as available for use."""
         try:
             self.client.apps.enableApp(appId=app_id)
             self.logger.success(f"The app '{app_id}' was enabled\n")
@@ -76,7 +76,7 @@ class Apps(TapipyCategory):
             self.logger.error(f"App not found with id '{app_id}'\n") 
 
     def get(self, app_id) -> None:
-        """ Retrieve the details of an application's latest version. """
+        """Retrieve the details of an application's latest version."""
         try:
             app = self.client.apps.getAppLatestVersion(appId=app_id)
             self.logger.log(app)
@@ -91,7 +91,7 @@ class Apps(TapipyCategory):
             self.exit(1)
 
     def getversion(self, app_id, version) -> None:
-        """ Retrieve the details of the specified version of an application. """
+        """Retrieve the details of the specified version of an application."""
         try:
             app = self.client.apps.getApp(appId=app_id, appVersion=version)
             self.logger.log(app)
@@ -106,7 +106,7 @@ class Apps(TapipyCategory):
             self.exit(1)
 
     def getperms(self, app_id, username) -> None:
-        """ Get the permissions that a specified user has on a target application. """
+        """Get the permissions that a specified user has on a target application."""
         creds = self.client.apps.getUserPerms(appId=app_id, userName=username)
         self.logger.log(creds)
         print()
@@ -114,7 +114,7 @@ class Apps(TapipyCategory):
         return
 
     def grantperms(self, app_id, username, *args) -> None:
-        """ Give permissions to a specified user on a target application. """
+        """Give permissions to a specified user on a target application."""
         perms = [arg.upper() for arg in args]
 
         # The expected input should be a JSONArray, NOT a JSONObject.
@@ -124,7 +124,7 @@ class Apps(TapipyCategory):
         return
 
     def list(self) -> None:
-        """ List every application on the systems in this tenant and environment. """
+        """List every application on the systems in this tenant and environment."""
         apps = self.client.apps.getApps()
         if len(apps) > 0:
             print()
@@ -177,7 +177,7 @@ class Apps(TapipyCategory):
             self.exit(1)
 
     def revokeperms(self, app_id, username, *args) -> None:
-        """ Revoke permissions from a specified user on a target application. """
+        """Revoke permissions from a specified user on a target application."""
         perms = [arg.upper() for arg in args]
 
         # The expected input should be a JSONArray, NOT a JSONObject
@@ -200,7 +200,7 @@ class Apps(TapipyCategory):
         return
 
     def undelete(self, app_id) -> None:
-        """ Undelete an applications that has been "soft" deleted. """
+        """Undelete an applications that has been "soft" deleted."""
         try:
             self.client.apps.undeleteApp(appId=app_id)
             self.logger.success(f"Recovered app with id '{app_id}'\n")

--- a/categories/Auth.py
+++ b/categories/Auth.py
@@ -1,15 +1,15 @@
-""" Handles the configuring of credentials. """
+"""Handles the configuring of credentials."""
 
 from core.Category import Category
 from core.Configuration import Configuration
 
 
 class Auth(Category):
-    """ Configurations are parsed here. """
+    """Configurations are parsed here."""
     def __init__(self):
         Category.__init__(self)
         self.config = Configuration()
 
     def configure(self):
-        """ Configures the settings to handle input credentials. """
+        """Configures the settings to handle input credentials."""
         self.config.configure()

--- a/categories/Files.py
+++ b/categories/Files.py
@@ -1,4 +1,4 @@
-""" Handles TAPIS functionality related to files. """
+"""Handles TAPIS functionality related to files."""
 
 import os
 
@@ -7,12 +7,12 @@ from tapipy.errors import InvalidInputError
 
 
 class Files(TapipyCategory):
-    """ Contains all of the CRUD functions associated with files. """
+    """Contains all of the CRUD functions associated with files."""
     def __init__(self):
         TapipyCategory.__init__(self)
         
     def delete(self, system_id, path) -> None:
-        """ Deletes the specified file from the target system. """
+        """Deletes the specified file from the target system."""
         try:
             self.client.files.delete(systemId=system_id, path=path)
             self.logger.info(f"Deleted file '{path}' in system '{system_id}'\n")
@@ -22,7 +22,7 @@ class Files(TapipyCategory):
             return
 
     def get_contents(self, system_id, path) -> None:
-        """ Retrieves the contents of the specified file in the target system. """
+        """Retrieves the contents of the specified file in the target system."""
         try:
             contents = self.client.files.getContents(systemId=system_id, path=path)
             print()
@@ -34,7 +34,7 @@ class Files(TapipyCategory):
             return
         
     def list(self, system_id, path) -> None:
-        """ List every file on the target system. """
+        """List every file on the target system."""
         # BUG Seems to be breaking a LOT... very rarely works.
         files = self.client.files.listFiles(systemId=system_id, path=path)
         for file in files:

--- a/categories/Jobs.py
+++ b/categories/Jobs.py
@@ -1,4 +1,4 @@
-""" Handles TAPIS functionaloty related to jobs. """
+"""Handles TAPIS functionaloty related to jobs."""
 
 from datetime import datetime
 
@@ -7,12 +7,12 @@ from tapipy.errors import InvalidInputError
 
 
 class Jobs(TapipyCategory):
-    """ Contains all of the CRUD functions associated with jobs. """
+    """Contains all of the CRUD functions associated with jobs."""
     def __init__(self):
         TapipyCategory.__init__(self)
 
     def download(self, uuid, output_path) -> None:
-        """ Downloads the output of a completed job. """
+        """Downloads the output of a completed job."""
         try:
             self.client.jobs.getJobOutputDownload(jobUuid=uuid, outputPath=output_path)
             self.logger.complete(f"\nDownload complete for job '{uuid}'\n")
@@ -22,7 +22,7 @@ class Jobs(TapipyCategory):
             return
 
     def get(self, uuid) -> None:
-        """ Retrieve the details of a specified job. """
+        """Retrieve the details of a specified job."""
         try:
             job = self.client.jobs.getJob(jobUuid=uuid)
             self.logger.log(job)
@@ -33,7 +33,7 @@ class Jobs(TapipyCategory):
             return
 
     def history(self, uuid) -> None:
-        """ Retrieve the computation history of a specified job. """
+        """Retrieve the computation history of a specified job."""
         try:
             status = self.client.jobs.getJobHistory(jobUuid=uuid)
             self.logger.log(status)
@@ -44,7 +44,7 @@ class Jobs(TapipyCategory):
             self.exit(1)
 
     def status(self, uuid) -> None:
-        """ Retrieve the current operational status of a specified job. """
+        """Retrieve the current operational status of a specified job."""
         try:
             status = self.client.jobs.getJobStatus(jobUuid=uuid)
             self.logger.log(status)
@@ -55,14 +55,14 @@ class Jobs(TapipyCategory):
             self.exit(1)
 
     def list(self) -> None:
-        """ Retrieve the current list of submitted jobs. """
+        """Retrieve the current list of submitted jobs."""
         jobs = self.client.jobs.getJobList()
         self.logger.log(jobs)
 
         return
 
     def submit(self, app_id, app_version, *args) -> None:
-        """ Submit a job to be run using a specified application and its version. """
+        """Submit a job to be run using a specified application and its version."""
         # Set the name and description to datetime-appid-username
         name = f"{datetime.now()}-{app_id}-{self.client.username}"
         description = name
@@ -80,7 +80,7 @@ class Jobs(TapipyCategory):
             self.exit(1)
 
     def resubmit(self, uuid) -> None:
-        """ Re-submit a job using a specified job UUID. """
+        """Re-submit a job using a specified job UUID."""
         # TODO Some error
         try:
             self.client.jobs.resubmitJob(jobuuid=uuid)

--- a/categories/Systems.py
+++ b/categories/Systems.py
@@ -1,4 +1,4 @@
-""" Handles TAPIS functionality related to systems. """
+"""Handles TAPIS functionality related to systems."""
 
 import json
 
@@ -7,12 +7,12 @@ from tapipy.errors import InvalidInputError
 
 
 class Systems(TapipyCategory):
-    """ Contains all of the CRUD functions associated with systems. """
+    """Contains all of the CRUD functions associated with systems."""
     def __init__(self):
         TapipyCategory.__init__(self)
 
     def available(self, system_id) -> None:
-        """ Check if a system is currently enabled. """
+        """Check if a system is currently enabled."""
         try:
             system = self.client.systems.isEnabled(systemId=system_id)
             status = "enabled" if system.aBool else "disabled" 
@@ -32,7 +32,7 @@ class Systems(TapipyCategory):
         return
 
     def create(self, system_definition_file: str) -> None:
-        """ Create a new system from a system definition JSON file. """
+        """Create a new system from a system definition JSON file."""
         definition = json.loads(open(system_definition_file, "r").read())
         self.client.systems.createSystem(**definition)
         self.logger.success(f"System \'{definition['id']}\' created\n")
@@ -64,7 +64,7 @@ class Systems(TapipyCategory):
             return
 
     def disable(self, system_id) -> None:
-        """ Mark (all versions of) a system as unavailable for use. """
+        """Mark (all versions of) a system as unavailable for use."""
         try:
             self.client.systems.disableSystem(systemId=system_id)
             self.logger.success(f"The system '{system_id}' was disabled\n")
@@ -74,7 +74,7 @@ class Systems(TapipyCategory):
             return       
 
     def enable(self, system_id) -> None:
-        """ Mark (all versions of) a system as available for use. """
+        """Mark (all versions of) a system as available for use."""
         try:
             self.client.systems.enableSystem(systemId=system_id)
             self.logger.success(f"The system '{system_id}' was enabled\n")
@@ -84,7 +84,7 @@ class Systems(TapipyCategory):
             return   
 
     def get(self, system_id) -> None:
-        """ Retrieve the details of an system's latest version. """
+        """Retrieve the details of an system's latest version."""
         try:
             system = self.client.systems.getSystem(systemId=system_id)
             self.logger.log(system)
@@ -95,14 +95,14 @@ class Systems(TapipyCategory):
             return
 
     def getcreds(self) -> None:
-        """ Get a specified user's credentials. """
+        """Get a specified user's credentials."""
         # TODO
         self.logger.warn("get_credentials not implemented\n")
 
         return
  
     def getperms(self, system_id, username) -> None:
-        """ Get the permissions that a specified user has on a target system. """
+        """Get the permissions that a specified user has on a target system."""
         creds = self.client.systems.getUserPerms(systemId=system_id, userName=username)
         self.logger.log(creds)
         print()
@@ -110,7 +110,7 @@ class Systems(TapipyCategory):
         return
 
     def grantperms(self, system_id, username, *args) -> None:
-        """ Give permissions to a specified user on a target application. """
+        """Give permissions to a specified user on a target application."""
         perms = [arg.upper() for arg in args]
 
         # The expected input should be a JSONArray, NOT a JSONObject.
@@ -121,7 +121,7 @@ class Systems(TapipyCategory):
         return
 
     def list(self) -> None:
-        """ List every system in this tenant and environment. """
+        """List every system in this tenant and environment."""
         systems = self.client.systems.getSystems()
         if len(systems) > 0:
             print()
@@ -166,7 +166,7 @@ class Systems(TapipyCategory):
             self.exit(1)
 
     def revokeperms(self, system_id, username, *args) -> None:
-        """ Revoke permissions from a specified user on a target system. """
+        """Revoke permissions from a specified user on a target system."""
         perms = [arg.upper() for arg in args]
 
         # The expected input should be a JSONArray, NOT a JSONObject.
@@ -189,7 +189,7 @@ class Systems(TapipyCategory):
         return
 
     def undelete(self, system_id) -> None:
-        """ Undelete an applications that has been "soft" deleted. """
+        """Undelete an applications that has been "soft" deleted."""
         try:
             self.client.systems.undeleteSystem(systemId=system_id)
             self.logger.success(f"Recovered system with id '{system_id}'\n")
@@ -199,7 +199,7 @@ class Systems(TapipyCategory):
             return
 
     def update_creds(self, file) -> None:
-        """ Update user credentials using a JSON definition file containing credentials. """
+        """Update user credentials using a JSON definition file containing credentials."""
         creds = json.loads(open(file, "r").read())
         self.client.systems.createUserCredential(**creds)
 

--- a/categories/Tenants.py
+++ b/categories/Tenants.py
@@ -1,16 +1,16 @@
-""" Handles TAPIS functionality related to tenants. """
+"""Handles TAPIS functionality related to tenants."""
 
 from core.TapipyCategory import TapipyCategory
 from tapipy.errors import InvalidInputError
 
 
 class Tenants(TapipyCategory):
-    """ Contains all CRUD functions associated with tenants. """
+    """Contains all CRUD functions associated with tenants."""
     def __init__(self):
         TapipyCategory.__init__(self)
 
     def get(self, tenant_id) -> None:
-        """ Retrieve the details of a specified tenant. """
+        """Retrieve the details of a specified tenant."""
         try:
             tenant = self.client.tenants.get_tenant(tenantId=tenant_id)
             self.logger.log(tenant)
@@ -21,7 +21,7 @@ class Tenants(TapipyCategory):
             return
 
     def list(self) -> None:
-        """ List every tenant on the site. """
+        """List every tenant on the site."""
         tenants = self.client.tenants.list_tenants()
         if len(tenants) > 0:
             print()

--- a/configs/settings.py
+++ b/configs/settings.py
@@ -1,8 +1,3 @@
-APP_REGISTRY = [
-    "core",
-    "tapis"
-]
-
 """ 
 All settings and configurable variables, such as environment varaibles, go here.
 
@@ -16,6 +11,11 @@ of development for a feature or for testing purposes. For example:
 
 NOTE: The TACC tenant in production is tacc.tapis.io, not tacc.prod.tapis.io!
 """
+
+APP_REGISTRY = [
+    "core",
+    "tapis"
+]
 
 AUTH_METHOD = "PASSWORD"
 

--- a/core/Authenticator.py
+++ b/core/Authenticator.py
@@ -1,4 +1,4 @@
-""" Handles the checking and authentication of user credentials. """
+"""Handles the checking and authentication of user credentials."""
 
 import sys
 from typing import Union
@@ -10,7 +10,7 @@ from utils.Logger import Logger
 
 
 class Authenticator:
-    """ Authorization credentials are parsed here. """
+    """Authorization credentials are parsed here."""
     base_url = ""
     auth_methods = settings.AUTH_METHODS
 
@@ -51,7 +51,7 @@ class Authenticator:
             raise ValueError(f"Invalid auth_method: {auth_method}. Valid auth_method: {settings.AUTH_METHODS}\n")
 
     def validate_credentials(self, auth_method: str, credentials: dict) -> None:
-        """ Checks to see if the user's credentials exist already. """
+        """Checks to see if the user's credentials exist already."""
         if auth_method == "PASSWORD":
             if not self.keys_in_dict(["username", "password"], credentials):
                 raise ValueError("Provided credentials must contain a 'username' and 'password'\n")
@@ -59,7 +59,7 @@ class Authenticator:
         return
 
     def keys_in_dict(self, keys: list, dict: dict) -> bool:
-        """ Iterates through the dictionary of known keys to find user credentials. """
+        """Iterates through the dictionary of known keys to find user credentials."""
         for key in keys:
             if key not in dict:
                 return False

--- a/core/Category.py
+++ b/core/Category.py
@@ -59,7 +59,7 @@ class Category:
         return
     
     def set_options(self, options: list) -> None:
-        """ Any options for the command are logged to the class. """
+        """Any options for the command are logged to the class."""
         self.options = options
 
         return
@@ -69,14 +69,14 @@ class Category:
         return
 
     def execute(self, args) -> None:
-        """ The command is executed (along with its options). """
+        """The command is executed (along with its options)."""
         method = getattr(self, self.command)
         method(*args)
 
         return
 
     def get_methods(self, instance: object) -> list:
-        """ Returns all of the methods that are available for the specified category. """
+        """Returns all of the methods that are available for the specified category."""
         # Get all props of of the instance.
         class_props = dir(instance)
 

--- a/core/Configuration.py
+++ b/core/Configuration.py
@@ -1,4 +1,4 @@
-""" Handles the setup of authorization credentials. """
+"""Handles the setup of authorization credentials."""
 
 import os
 import sys

--- a/core/OpenApiCategory.py
+++ b/core/OpenApiCategory.py
@@ -1,11 +1,15 @@
+"""
+Handles the parsing and execution of commands specified in the OpenAPI specs.
+
+Different tools, such as Tapipy, may inherit from this to specify their own
+specific categories and commands.
+"""
+
 from core.TapipyCategory import TapipyCategory
 
 # TODO Use client initialization logic from Tapipy in OpenApiCategory
 class OpenApiCategory(TapipyCategory):
-    """
-    Overwrites the execute method to access the
-    Tapipy client directly
-    """
+    """Overwrites the execute method to access the Tapipy client directly."""
     operation = None
     resource = None
 
@@ -13,6 +17,7 @@ class OpenApiCategory(TapipyCategory):
         TapipyCategory.__init__(self)
 
     def execute(self, args) -> None:
+        """Executes the OpenAPI command."""
         try:
             self.validate_keyword_args()
 
@@ -36,6 +41,7 @@ class OpenApiCategory(TapipyCategory):
             self.logger.error(e)
 
     def set_operation(self, operation_name: str) -> None:
+        """Sets the operation to be performed upon execution."""
         try:
             self.operation = getattr(self.resource, operation_name)
             return
@@ -44,6 +50,7 @@ class OpenApiCategory(TapipyCategory):
             self.exit(1)
 
     def set_resource(self, resource_name: str) -> None:
+        """Gets the resource name for the OpenAPI command."""
         try:
             self.resource = getattr(self.client, resource_name)
             return
@@ -52,6 +59,7 @@ class OpenApiCategory(TapipyCategory):
             self.exit(1)
 
     def validate_keyword_args(self):
+        """Validates the keywords required by an OpenAPI command."""
         required_params = []
         for param in self.operation.path_parameters:
             if param.required:

--- a/core/Router.py
+++ b/core/Router.py
@@ -1,4 +1,4 @@
-""" Handles the resolving (parsing) of commands and their options. """
+"""Handles the resolving (parsing) of commands and their options."""
 
 import re
 
@@ -21,7 +21,7 @@ class Router:
         self.logger = Logger()
 
     def resolve(self, args: List[str]) -> Tuple[Category, List[str]]:
-        """ The command is resolved here. """
+        """The command is resolved here."""
 
         # Parse the arguments and extract the values
         (
@@ -73,7 +73,7 @@ class Router:
         
         
     def parse_options(self, args: List[str]) -> List[str]:
-        """Extract options from the args"""
+        """Extract options from the arguments."""
         # Regex pattern for options.
         pattern = re.compile(r"^[-]{1}[a-z]+[a-z_]*$")
         # First arg in the args list is the category.
@@ -90,6 +90,7 @@ class Router:
         return options
 
     def parse_keyword_args(self, args: List[str]) -> Dict[str, str]:
+        """Parse keywords passed in as arguments."""
         # Regex pattern for keyword args and their values
         # NOTE This is a weak pattern. Doesn't allow for "=" in 
         # the value of the keword argument AND double quotes
@@ -103,6 +104,7 @@ class Router:
         return (dict(pattern.findall(" " + " ".join(args))))
 
     def parse_args(self, args: List[str]) -> Tuple[str, str, List, Dict, List]:
+        """Parse non-keyword arguments."""
         # Category name
         category_name: str = args[0]
         # Parse the options from the args. This also keeps determines the

--- a/core/TapipyCategory.py
+++ b/core/TapipyCategory.py
@@ -1,4 +1,4 @@
-""" Handles the functionality of TAPIS commands specifically. """
+"""Handles the functionality of TAPIS commands specifically."""
 
 import re
 from typing import Union
@@ -10,7 +10,7 @@ from tapipy.tapis import Tapis
 
 
 class TapipyCategory(Category):
-    """ A TAPIS-specific category. """
+    """A TAPIS-specific category."""
     client: Union[Tapis, None] = None
 
     def __init__(self):
@@ -25,7 +25,7 @@ class TapipyCategory(Category):
             raise ValueError(f"Unable to authenticate user using AUTH_METHOD {settings.AUTH_METHOD}\n")
 
     def methods(self) -> None:
-        """ Returns all of the methods associated with a particular category. """
+        """Returns all of the methods associated with a particular category."""
         all_methods = dir(getattr(self.client, type(self).__name__.lower()))
         methods = []
 

--- a/core/errors.py
+++ b/core/errors.py
@@ -1,4 +1,7 @@
+"""Handles errors associated with CLI functionality and inputs."""
+
 class CLIBaseError(Exception):
+    """The basic error class that more specific errors may inherit from."""
     def __init__(self, message):
         self.message = message
 
@@ -9,8 +12,10 @@ class CLIBaseError(Exception):
         return str(self)
 
 class InvalidCategoryError(CLIBaseError):
+    """Deals with incorrect categories being input to the CLI."""
     pass
 
 class InvalidCommandError(CLIBaseError):
+    """Deals with incorrect commands being input to the CLI."""
     pass
         

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
-""" The front-controller the TAPIs command line tool. """
+"""The front-controller the TAPIs command line tool."""
 import sys
 from core.Router import Router
 
 def main():
-    """ Resolve the category, command, options, and arguments, then execute them. """
+    """Resolve the category, command, options, and arguments, then execute them."""
     (category, args) = Router().resolve(sys.argv[1:])
     category.execute(args)
     

--- a/utils/Logger.py
+++ b/utils/Logger.py
@@ -1,7 +1,7 @@
-""" Handles the error/success/info logging and sets their printed styles. """
+"""Handles the error/success/info logging and sets their printed styles."""
 
 class styles:
-    """ The colors associated with the logging messages. """
+    """The colors associated with the logging messages."""
     DEBUG = '\033[95m'
     BLUE = '\033[94m'
     SUCCESS = '\033[92m'
@@ -13,7 +13,7 @@ class styles:
     UNDERLINE = '\033[4m'
 
 class Logger:
-    """ Contains the various log categories and their printed messages. """
+    """Contains the various log categories and their printed messages."""
     def complete(self, message):
         # Typically used for signifying that a task is done.
         print(f"{styles.SUCCESS}{styles.BOLD}✓{styles.RESET} {message}")


### PR DESCRIPTION
Removing the spaces at the beginning and end of the single-line docstrings to conform to standards; also adding missing docstrings.

### Overview:

### Github Issue Links:
[Task 6](https://github.com/nathandf/tapis-cli/issues/6)

### Summary of changes:
- Removed the spaces at the beginning and end of every single-line docstring as per Python standards.
    - Example: """ Docstring 1 here. """   -->   """Docstring 1 here.""" 
- Added docstrings for new modules that were missing them. 

### Steps-to-test:
- N/A

### Notes:
