### PR TITLE
Task/7  argument options

### DIFF
--- a/core/Category.py
+++ b/core/Category.py
@@ -20,6 +20,7 @@ class Category:
     """
     options = []
     keyword_args: Dict[str, str] = {}
+    arg_options: Dict[str, str] = {}
     command = "help"
     logger = None
     exit = sys.exit
@@ -66,6 +67,10 @@ class Category:
 
     def set_keyword_args(self, keyword_args: Dict[str, str]) -> None:
         self.keyword_args = keyword_args
+        return
+
+    def set_arg_options(self, arg_options: Dict[str, str]) -> None:
+        self.arg_options = arg_options
         return
 
     def execute(self, args) -> None:

--- a/core/OpenApiCategory.py
+++ b/core/OpenApiCategory.py
@@ -14,6 +14,8 @@ class OpenApiCategory(TapipyCategory):
 
     def execute(self, args) -> None:
         try:
+            self.validate_keyword_args()
+
             if len(args) == 0 and len(self.keyword_args) == 0:
                 result = self.operation()
             elif len(args) > 0 and len(self.keyword_args) == 0:
@@ -48,3 +50,14 @@ class OpenApiCategory(TapipyCategory):
         except:
             self.logger.error(f"{type(self).__name__} has no resource '{resource_name}'\n")
             self.exit(1)
+
+    def validate_keyword_args(self):
+        required_params = []
+        for param in self.operation.path_parameters:
+            if param.required:
+                required_params.append(param.name)
+
+        keyword_arg_keys = self.keyword_args.keys()
+        for param in required_params:
+            if param not in keyword_arg_keys:
+                raise Exception(f"'{param}' is a required keyword argument. Required keyword arguments: {required_params}")

--- a/core/OpenApiCategory.py
+++ b/core/OpenApiCategory.py
@@ -59,6 +59,7 @@ class OpenApiCategory(TapipyCategory):
             self.exit(1)
 
     def validate_keyword_args(self):
+        """Validates the keywords required by an OpenAPI command."""
         required_params = []
         for param in self.operation.path_parameters:
             if param.required:

--- a/core/Router.py
+++ b/core/Router.py
@@ -32,11 +32,6 @@ class Router:
             positional_args
         ) = self.parse_args(args)
 
-        self.logger.debug(f"All args: {args}")
-        self.logger.debug(f"Options: {options}")
-        self.logger.debug(f"kwargs: {keyword_args}")
-        self.logger.debug(f"Positional args: {positional_args}")
-
         # The first step of command resolution is to check if a 
         # user-defined category exists by the name provided in args.
         if find_spec(f"categories.{category_name.capitalize()}") is not None:

--- a/handlers/arg_options/ArgOptionHandler.py
+++ b/handlers/arg_options/ArgOptionHandler.py
@@ -1,0 +1,47 @@
+import os, json
+
+class ArgOptionHandler:
+
+    category = None
+    args = []
+    arg_option_map = {}
+
+    def __init__(self, arg_option_map={}):
+        self.arg_option_map = arg_option_map
+
+    def handle(self, category, args):
+        self.category = category
+        self.args = args
+
+        for option in self.category.arg_options.keys():
+            if option not in self.arg_option_map:
+                raise ValueError(f"Handler '{type(self).__name__}' is not configured to accept '-{option}' as an option")
+
+            if not hasattr(self, self.arg_option_map[option]):
+                raise Exception(f"Handler function '{self.arg_option_map[option]}' exists")
+
+            fn = getattr(self, self.arg_option_map[option])
+            try:
+                fn()
+            except Exception as e:
+                raise Exception(e)
+
+        return self.args
+
+    def jsonFileToKeywordArgs(self):
+        _, extension = os.path.splitext(self.category.arg_options["j"])
+        # Check that the extension of the file is '.json'
+        if extension != ".json":
+            raise ValueError(f"Using argument option '-j' requires a json file argument. Provided: '{extension}' ")
+        # Convert the definition file into a json object
+        obj = json.loads(open(self.category.arg_options["j"], "r").read())
+        for item, value in obj.items():
+            self.category.keyword_args[item] = value
+        
+        return
+
+    def fileContentsToPositionalArg(self):
+        file_contents = open(self.category.arg_options["f"], "rb").read()
+        self.args.append(file_contents)
+
+        return

--- a/handlers/arg_options/OpenApiCategory.py
+++ b/handlers/arg_options/OpenApiCategory.py
@@ -1,0 +1,9 @@
+from handlers.arg_options.ArgOptionHandler import ArgOptionHandler
+
+class OpenApiCategory(ArgOptionHandler):
+    def __init__(self, arg_option_map = {
+        "j": "jsonFileToKeywordArgs",
+        "f": "fileContentsToPositionalArg"
+    }):
+        ArgOptionHandler.__init__(self, arg_option_map=arg_option_map)
+                


### PR DESCRIPTION
### Overview:
Implement arg option handler. The two options handled for are '-j' and 'f'. The former will convert a json file into keyword arguments, and the latter will take the binary contents of a file and add it as a keyword argument.

### Github Issue Links:
[Task 7](https://github.com/nathandf/tapis-cli/issues/7)

### Summary of changes:
- Create base ArgOptionHandler class
- Create category-specific arg option handler that inherits from the base ArgOptionHandlerClass
- Specify the mapping of options to methods in the category-specific arg option handler
- Handle for -j and -f flags

### Steps-to-test:
- create a definition file that contains an object with a property 'systemId'
- `tapis systems getSystem -j <path_to_file.json>` where '<path_to_file.json>' is the json file you just created
- Result should be that 'systemId' and all other properties contained in that object will be added as keyword arguments on the category. If the systemId is valid, it will return a system. If incorrect, it will thrown an error

### Notes:
Additional arguments will be handled for at a later time